### PR TITLE
Create todo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'figaro', '1.0'
 gem 'bootstrap-sass', '~> 3.3.1'
 gem 'pundit'
 gem 'whenever', :require => false
+gem 'active_model_serializers'
 
 group :development, :test do
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,8 @@ GEM
       erubis (~> 2.7.0)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
+    active_model_serializers (0.9.2)
+      activemodel (>= 3.2)
     activemodel (4.0.10)
       activesupport (= 4.0.10)
       builder (~> 3.1.0)
@@ -173,6 +175,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   bootstrap-sass (~> 3.3.1)
   capybara
   coffee-rails (~> 4.0.0)

--- a/app/controllers/api/v1/todos_controller.rb
+++ b/app/controllers/api/v1/todos_controller.rb
@@ -5,8 +5,8 @@ class Api::V1::TodosController < Api::ApiController
     user = User.find_by_auth_token(request.headers["Authorization"])
 
     if user
-      user.todos.create(description: params[:description])
-      head :no_content
+      todo = user.todos.create(description: params[:description])
+      render json: {id: todo.id, description: todo.description}, status: :created
     else
       render json: {message: "Unauthorized"}, status: :unauthorized
     end

--- a/app/controllers/api/v1/todos_controller.rb
+++ b/app/controllers/api/v1/todos_controller.rb
@@ -1,6 +1,17 @@
 class Api::V1::TodosController < Api::ApiController
   rescue_from ActiveRecord::RecordNotFound, with: :not_found_response
 
+  def create
+    user = User.find_by_auth_token(request.headers["Authorization"])
+
+    if user
+      user.todos.create(description: params[:description])
+      head :no_content
+    else
+      render json: {message: "Unauthorized"}, status: :unauthorized
+    end
+  end
+
   def destroy
     todo = Todo.find(params[:id])
     user = User.find_by_auth_token(request.headers["Authorization"])

--- a/app/controllers/api/v1/todos_controller.rb
+++ b/app/controllers/api/v1/todos_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::TodosController < Api::ApiController
 
     if user
       todo = user.todos.create(description: params[:description])
-      render json: {id: todo.id, description: todo.description}, status: :created
+      render json: TodoSerializer.new(todo).to_json, status: :created
     else
       render json: {message: "Unauthorized"}, status: :unauthorized
     end

--- a/app/serializers/todo_serializer.rb
+++ b/app/serializers/todo_serializer.rb
@@ -1,0 +1,3 @@
+class TodoSerializer < ActiveModel::Serializer
+  attributes :id, :description
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Blocitoff::Application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :todos, only: [:destroy]
+      resources :todos, only: [:create, :destroy]
     end
   end
 end

--- a/spec/requests/api/todos_request_spec.rb
+++ b/spec/requests/api/todos_request_spec.rb
@@ -60,7 +60,6 @@ describe "Todos API" do
       post "/api/v1/todos", {description: "Finish Blocitoff"}, "Authorization" => user.auth_token
 
       expect(response.status).to eq(201)
-      json = JSON.parse(response.body, symbolize_names: true)
       expect(json[:todo][:id]).to eq(Todo.last.id)
       expect(json[:todo][:description]).to eq("Finish Blocitoff")
       expect(Todo.count).to eq(1)

--- a/spec/requests/api/todos_request_spec.rb
+++ b/spec/requests/api/todos_request_spec.rb
@@ -61,8 +61,8 @@ describe "Todos API" do
 
       expect(response.status).to eq(201)
       json = JSON.parse(response.body, symbolize_names: true)
-      expect(json[:id]).to eq(Todo.last.id)
-      expect(json[:description]).to eq("Finish Blocitoff")
+      expect(json[:todo][:id]).to eq(Todo.last.id)
+      expect(json[:todo][:description]).to eq("Finish Blocitoff")
       expect(Todo.count).to eq(1)
     end
 

--- a/spec/requests/api/todos_request_spec.rb
+++ b/spec/requests/api/todos_request_spec.rb
@@ -59,7 +59,10 @@ describe "Todos API" do
 
       post "/api/v1/todos", {description: "Finish Blocitoff"}, "Authorization" => user.auth_token
 
-      expect(response.status).to eq(204)
+      expect(response.status).to eq(201)
+      json = JSON.parse(response.body, symbolize_names: true)
+      expect(json[:id]).to eq(Todo.last.id)
+      expect(json[:description]).to eq("Finish Blocitoff")
       expect(Todo.count).to eq(1)
     end
 

--- a/spec/requests/api/todos_request_spec.rb
+++ b/spec/requests/api/todos_request_spec.rb
@@ -74,18 +74,6 @@ describe "Todos API" do
       expect(Todo.count).to eq(0)
     end
 
-    it "prevents logged in attacker from creating todos in other accounts" do
-      victim = create(:user)
-      attacker = create(:user)
-
-      post "/api/v1/todos", {description: "Finish Blocitoff"}, "Authorization" => attacker.auth_token
-
-      expect(response.status).to eq(403)
-      expect(json[:message]).to eq("Forbidden")
-      expect(response.content_type).to eq("application/json")
-      expect(Todo.count).to eq(0)
-    end
-
   end
 
   private


### PR DESCRIPTION
This seems to be working; I user-tested it out using curl:
`curl --data "description=new todo" http://localhost:3000/api/v1/todos --header "Authorization":"esnB6zbP5NPW-2iKs8js"`

I used the logic you suggested for the destroy method here, since it only has one alternate response ("Unauthorized").

Let me know what you think!
