### PR TITLE
remove row number updater from javascript

### DIFF
--- a/app/assets/javascripts/todo.js
+++ b/app/assets/javascripts/todo.js
@@ -41,12 +41,6 @@
       var todoRow = clickedElement.closest("tr");
       var rowNumber = todoRow.find('td').html();
       todoRow.fadeOut("normal", function() { $(this).remove(); });
-      todoRow.nextAll('tr').find('td:first').each(function(i, rowIndex) { updateRows(rowIndex); });
-
-      function updateRows(rowIndex) {
-        $(rowIndex).html(rowNumber);
-        rowNumber++;
-      }
     }
 
 


### PR DESCRIPTION
Since the index cell was removed from each todo row, it's no longer needed. It was causing the rows below the deleted todo to disappear.
