### PR TITLE
Destroy todos when list is destroyed

### DIFF
--- a/app/controllers/api/v1/todos_controller.rb
+++ b/app/controllers/api/v1/todos_controller.rb
@@ -8,6 +8,8 @@ class Api::V1::TodosController < Api::ApiController
 
     if description.strip.length == 0
       render json: {errors: "No Description"}, status: :not_acceptable
+    elsif !list_id
+      render json: {errors: "No List"}, status: :not_acceptable
     elsif user
       todo = user.todos.create(description: description, list_id: list_id)
       render json: TodoSerializer.new(todo).to_json, status: :created

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,6 +1,6 @@
 class List < ActiveRecord::Base
   belongs_to :user
-  has_many :todos
+  has_many :todos, dependent: :destroy
   scope :recently_updated, -> { order(updated_at: :desc) }
 
   validates :name, presence: true

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -5,4 +5,5 @@ class Todo < ActiveRecord::Base
 
   validates :description, presence: true
   validates :user_id, presence: :true
+  validates :list_id, presence: true
 end

--- a/db/data/20160629052724_add_list_to_todos.rb
+++ b/db/data/20160629052724_add_list_to_todos.rb
@@ -1,0 +1,27 @@
+class AddListToTodos < ActiveRecord::Migration
+  def self.up
+    users_with_todos = User.joins(:todos).uniq.all
+
+    users_with_todos.each do |user|
+      todos_from_deleted_lists = []
+      user.todos.each do |todo|
+        begin
+          List.find(todo.list_id)
+        rescue ActiveRecord::RecordNotFound => e
+          todos_from_deleted_lists << todo
+        end
+      end
+
+      orphan_todos = todos_from_deleted_lists + user.todos.where(list_id: nil)
+
+      unless orphan_todos.empty?
+        orphan_todo_list = List.create(user: user, name: 'Orphan todos')
+        orphan_todos.each { |t| t.update(list_id: orphan_todo_list.id) }
+      end
+    end
+  end
+
+  def self.down
+    raise IrreversibleMigration
+  end
+end

--- a/db/migrate/20160629054938_change_todo_list_to_null_false.rb
+++ b/db/migrate/20160629054938_change_todo_list_to_null_false.rb
@@ -1,0 +1,5 @@
+class ChangeTodoListToNullFalse < ActiveRecord::Migration
+  def change
+    change_column_null :todos, :list_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151126051937) do
+ActiveRecord::Schema.define(version: 20160629054938) do
+
+  create_table "data_migrations", id: false, force: true do |t|
+    t.string "version", null: false
+  end
+
+  add_index "data_migrations", ["version"], name: "unique_data_migrations", unique: true
 
   create_table "lists", force: true do |t|
     t.string   "name",       null: false
@@ -27,7 +33,7 @@ ActiveRecord::Schema.define(version: 20151126051937) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id"
-    t.integer  "list_id"
+    t.integer  "list_id",     null: false
   end
 
   add_index "todos", ["list_id"], name: "index_todos_on_list_id"

--- a/spec/factories/todo.rb
+++ b/spec/factories/todo.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :todo do
     description "todo description"
     user
+    list
   end
 end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -15,7 +15,7 @@ describe List do
 
   context 'associations' do
     it { should belong_to(:user) }
-    it { should have_many(:todos) }
+    it { should have_many(:todos).dependent(:destroy) }
   end
 
   context "validations" do

--- a/spec/requests/api/todos_request_spec.rb
+++ b/spec/requests/api/todos_request_spec.rb
@@ -56,14 +56,13 @@ describe "Todos API" do
     before { @user = create(:user) }
 
     context 'without a list id' do
-      it "should create a todo with nil list_id" do
+      it "responds with a nil list error" do
         post "/api/v1/todos", {description: "Finish Breautodo"}, "Authorization" => @user.auth_token
 
-        expect(response.status).to eq(201)
-        expect(json[:todo][:id]).to eq(Todo.last.id)
-        expect(json[:todo][:description]).to eq("Finish Breautodo")
-        expect(json[:todo][:list_id]).to be_nil
-        expect(Todo.count).to eq(1)
+        expect(response.status).to eq(406)
+        expect(json[:errors]).to eq("No List")
+        expect(response.content_type).to eq("application/json")
+        expect(Todo.count).to eq(0)
       end
     end
 
@@ -83,8 +82,9 @@ describe "Todos API" do
 
     it "prevents anonymous attacker from creating" do
       user = create(:user)
+      list = create(:list)
 
-      post "/api/v1/todos", {description: "Finish Breautodo"}, "Authorization" => "fake-token"
+      post "/api/v1/todos", {description: "Finish Breautodo", list_id: list.id}, "Authorization" => "fake-token"
 
       expect(response.status).to eq(401)
       expect(json[:message]).to eq("Unauthorized")


### PR DESCRIPTION
Also, don't allow null list_id for todos (migration).

Add orphan todos to "Orphan todo" list for each user with orphan todos (data migration).
