### PR TITLE
Set dev and test databases to Postgres

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '2.3.4'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.6'
 
+gem 'pg', '~> 0.17'
 gem 'devise', '4.3.0'
 gem 'figaro', '1.0'
 gem 'pundit', '~> 0.3'
@@ -18,13 +19,8 @@ gem 'rails_autolink', '1.1.6'
 gem 'pry', group: [:development, :test]
 
 group :production do
-  gem 'pg', '~> 0.17'
   gem 'rails_12factor'
   gem 'puma', '~> 3.0'
-end
-
-group :development do
-  gem 'sqlite3', '~> 1.3'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.3.4'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.6'
 
-gem 'pg', '~> 0.17'
+gem 'pg', '~> 0.21.0'
 gem 'devise', '4.3.0'
 gem 'figaro', '1.0'
 gem 'pundit', '~> 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     orm_adapter (0.5.0)
-    pg (0.18.4)
+    pg (0.21.0)
     poltergeist (1.14.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -267,7 +267,7 @@ DEPENDENCIES
   haml-rails (~> 0.9)
   jbuilder (~> 2.7.0)
   jquery-rails (~> 4.3.1)
-  pg (~> 0.17)
+  pg (~> 0.21.0)
   poltergeist (~> 1.14.0)
   pry
   puma (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.11)
     susy (2.2.12)
       sass (>= 3.3.0, < 3.5)
     thor (0.20.0)
@@ -280,7 +279,6 @@ DEPENDENCIES
   sass-rails (~> 5.0.0)
   sdoc
   shoulda-matchers (~> 2.7)
-  sqlite3 (~> 1.3)
   susy (~> 2.2)
   timecop (~> 0.8.0)
   turbolinks (~> 5.0.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,83 @@
-# SQLite version 3.x
-#   gem install sqlite3
+# Install the pg driver:
+#   gem install pg
+# On OS X with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On OS X with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
 #
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
+# Configure Using Gemfile
+# gem 'pg'
+#
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # http://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+
 development:
-  adapter: sqlite3
-  database: db/development.sqlite3
-  pool: 5
-  timeout: 5000
+  <<: *default
+  database: breautodo_development
+
+  # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user that initialized the database.
+  #username: breautodo
+
+  # The password associated with the postgres role (username).
+  #password:
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+
+  # The TCP port the server listens on. Defaults to 5432.
+  # If your server runs on a different port number, change accordingly.
+  #port: 5432
+
+  # Schema search path. The server defaults to $user,public
+  #schema_search_path: breautodo,sharedapp,public
+
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # Defaults to warning.
+  #min_messages: notice
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: sqlite3
-  database: db/test.sqlite3
-  pool: 5
-  timeout: 5000
+  <<: *default
+  database: breautodo_test
 
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%= ENV['DATABASE_URL'] %>
+#
 production:
-  adapter: sqlite3
-  database: db/production.sqlite3
-  pool: 5
-  timeout: 5000
+  <<: *default
+  database: breautodo_production
+  username: breautodo
+  password: <%= ENV['MYAPP_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
also found that the database adapter was incorrectly configured to use sqlite for production, despite Heroku using postgres. Not sure how that worked without blowing up, but it's set straight now.